### PR TITLE
ImageGetInfo -> GetImageInfo

### DIFF
--- a/0.5.0/collage.md
+++ b/0.5.0/collage.md
@@ -204,7 +204,7 @@ Returns: `N/A`.
 
 Loads a texture page from cached memory.
 
-### `.ImageGetInfo(identifier)`
+### `.GetImageInfo(identifier)`
 
 Returns: `image` or `undefined`.
 

--- a/0.5.0/gettingstarted.md
+++ b/0.5.0/gettingstarted.md
@@ -104,7 +104,7 @@ sprite_delete(_batSprite);
 
 ?> Each `.Add*` method has some additional parameters, most are entirely optional. You can see more by reading their specific documentation under [Collage](collage.md).
 
-Once you've added your images, you can get their info via [`CollageImageGetInfo()`](image.md#collageimagegetinfoidentifier) or [`.ImageGetInfo()`](collage.md#imagegetinfoidentifier). Which you can then use to render the image.
+Once you've added your images, you can get their info via [`CollageImageGetInfo()`](image.md#collageimagegetinfoidentifier) or [`.GetImageInfo()`](collage.md#getimageinfoidentifier). Which you can then use to render the image.
 ```gml
 // Getting image info
 image = texPage.GetImageInfo("test");


### PR DESCRIPTION
This Pull Request fixes the documentation wrongly naming the method `GetImageInfo` as `ImageGetInfo`.

I noticed this issue while implementing this to my game, and also because on the examples it does show up as `GetImageInfo`, probably a tiny typo because of `CollageImageGetInfo` sounding so similar.